### PR TITLE
Fix Str class not found

### DIFF
--- a/src/Commands/ModelFromTableCommand.php
+++ b/src/Commands/ModelFromTableCommand.php
@@ -3,7 +3,7 @@
 namespace Laracademy\Generators\Commands;
 
 use DB;
-use Str;
+use Illuminate\Support\Str;
 use Schema;
 use Illuminate\Console\Command;
 

--- a/src/Commands/ModelFromTableCommand.php
+++ b/src/Commands/ModelFromTableCommand.php
@@ -3,8 +3,8 @@
 namespace Laracademy\Generators\Commands;
 
 use DB;
-use Illuminate\Support\Str;
 use Schema;
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 
 class ModelFromTableCommand extends Command


### PR DESCRIPTION
Fix "Class 'Str' not found" bug on Laravel 6.1+