### PR TITLE
Use Config to Generate Better Data

### DIFF
--- a/config/modelfromtable.php
+++ b/config/modelfromtable.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laracademy Generators
+    |--------------------------------------------------------------------------
+    |
+    | A tool set that helps speed up the development process of a Laravel application.
+    |
+    | Documentation and support:
+    | https://github.com/laracademy/generators
+    |
+    */
+
+    'connection' => '',
+
+    'namespace' => '',
+
+    'table' => '',
+
+    'primaryKey' => 'id',
+
+    'folder' => '',
+
+    'debug' => false,
+
+    'all' => false,
+
+    'singular' => false,
+
+    'overwrite' => false,
+
+    'blacklist' => ['migrations'],
+
+    'whitelist' => [],
+
+    'delimiter' => ', '
+];

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -20,11 +20,14 @@ class GeneratorsServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        //
+        $this->publishes([
+            __DIR__.'/../config/modelfromtable.php' => config_path('modelfromtable.php'),
+        ], 'modelfromtable');
     }
 
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/modelfromtable.php', 'modelfromtable');
         $this->registerModelGenerator();
     }
 

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -4,12 +4,11 @@ namespace {{modelnamespace}};
 
 use Illuminate\Database\Eloquent\Model;
 
-class {{class}} extends Model  
+/**{{docblock}}
+ */
+class {{class}} extends Model
 {
-
-    {{connection}}
-
-    /**
+    {{connection}}/**
      * The database table used by the model.
      *
      * @var string
@@ -17,31 +16,58 @@ class {{class}} extends Model
     protected $table = '{{table}}';
 
     /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = '{{primaryKey}}';
+
+    /**
      * Attributes that should be mass-assignable.
      *
      * @var array
      */
-    protected $fillable = [{{fillable}}];
+    protected $fillable = [
+        {{fillable}}
+    ];
 
     /**
      * The attributes excluded from the model's JSON form.
      *
      * @var array
      */
-    protected $hidden = [{{hidden}}];
+    protected $hidden = [
+        {{hidden}}
+    ];
 
     /**
      * The attributes that should be casted to native types.
      *
      * @var array
      */
-    protected $casts = [{{casts}}];
+    protected $casts = [
+        {{casts}}
+    ];
 
     /**
      * The attributes that should be mutated to dates.
      *
      * @var array
      */
-    protected $dates = [{{dates}}];
+    protected $dates = [
+        {{dates}}
+    ];
 
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var boolean
+     */
+    public $timestamps = {{timestamps}};
+
+    // Scopes...
+
+    // Functions ...
+
+    // Relations ...
 }


### PR DESCRIPTION
Apologies if this is too much change for one PR; I got on a bit of a run with the config feature (and a few things I needed to work with a very large database - specifically white/black listing) and thought I could also help fix some of the issues others had while I was in here.

Once I have your feedback and blessing, I can update the documentation here or in another PR.

- Establish a config file (modelfromtable.php) that devs can use to preset configurations (which can be overridden by command line) - downside is debug, all, etc have to be explicitly set to true in command line
- Use `app/Models` directory if Laravel 8+ (#40)
- New configuration to enable/disable timestamps (#13)
- Generating model docblocks (#7)
- New configuration to set delimiter (esp useful for tables with a lot of columns)
- New configuration that sets `overwrite` to `false` by default, much safer for models that a dev has created and modified (force them to overwrite explicitly)
- New configuration that sets `$primaryKey` - supports lambda to run database-specific query to obtain the primary key column
- Expanded on previous `$cast` types, tried to make it a little smarter with regex
- New configurations for whitelist and blacklist ("migrations" table included in config's blacklist by default, so devs have the choice to include it or not)
- General stub cleanup