### PR TITLE
Add minimum php version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Requirements
 
-1. PHP 5.6+
+1. PHP 7.4+
 2. Laravel 6.*
 3. MySQL *
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
             "email": "michael@laracademy.co"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=7.4"
+    },
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The arrow function  in `vendor/laracademy/generators/src/Commands/ModelFromTableCommand.php:316` requires min PHP 7.4