### PR TITLE
speed optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,6 @@ php artisan generate:modelfromtable --table=user --folder=app\Models
 ## Configuration file for saving defaults, dynamic lambdas
 A [config file](https://github.com/laracademy/generators/blob/master/config/modelfromtable.php) should be in your project's config folder (if not, you can easily create it). Through this, you can set defaults you commonly use to cut down on the input your command line call requires. Some fields, like `namespace`, accept a static value or, more powerfully, a lambda to generate dynamic values. Additional fields not available to the CLI are available in the config. See below.
 
-### Primary Key, using lamba (config only)
-Some apps do not use the Laravel default of `id`, so say your table name prefixes the primary key...
-```php
-'primaryKey' => fn(string $tableName) => "{$tableName}_id",
-```
-Some legacy databases do not conform to a standard, so a more powerful example could be querying the primary key column directly...
-```php
-'primaryKey' => (function (string $tableName) {
-    $primaryKey = collect(DB::select(DB::raw("SHOW KEYS FROM {$tableName} WHERE Key_name = 'PRIMARY'")))->first();
-    return ($primaryKey) ? $primaryKey->Column_name : false;
-}),
-```
-
 ### Whitelist/Blacklist (config only)
 Particularly large databases often have a number of tables that aren't meant to have models. These can easily be filtered through either the whitelist or blacklist (or both!). Laravel's "migrations" table is already included in the blacklist. One nice feature is that you can wildcard table names if that makes sense for your situation...
 ```php

--- a/config/modelfromtable.php
+++ b/config/modelfromtable.php
@@ -20,8 +20,6 @@ return [
 
     'table' => '',
 
-    'primaryKey' => 'id',
-
     'folder' => '',
 
     'filename' => '',

--- a/src/Commands/ModelFromTableCommand.php
+++ b/src/Commands/ModelFromTableCommand.php
@@ -223,6 +223,7 @@ class ModelFromTableCommand extends Command
         $stub = str_replace('{{connection}}', $this->stubConnection, $stub);
         $stub = str_replace('{{class}}', $table['file']['class'], $stub);
         $stub = str_replace('{{docblock}}', $stubDocBlock, $stub);
+        $stub = str_replace('{{table}}', $table['name'], $stub);
         $stub = str_replace('{{primaryKey}}', $primaryKey, $stub);
         $stub = str_replace('{{fillable}}', $stubFillable, $stub);
         $stub = str_replace('{{hidden}}', $stubHidden, $stub);


### PR DESCRIPTION
- significant speed optimizations by querying all tables and columns in a schema in one shot, rather than on a per-table basis. in my case, querying ~175 tables, it's about **40x faster**. added `$schema` option to config file so people can query the correct schema, but if that's not set i filter default system schemas so most users don't even need to set this.
- a nice bonus of this is i'm able to get the primary key from mysql at the same time, so i deprecated the `$primaryKey` option entirely (particularly nice for legacy databases like mine where i previously had to use a lambda to query each table's primary key because they're all weird). this much better addresses issue #48. not a breaking change.
- added a script execution timer
